### PR TITLE
Update deprecated command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
-# Set up your shiny OS X for software development
+# Set up your shiny OS X for software development <!-- omit in toc -->
 
 After having maintained [this gist](https://gist.github.com/danguita/6242852/revisions) with a bunch of [stargazers](https://gist.github.com/danguita/6242852/stargazers), I'd like to let people contribute here. Feel free to pull request!
 
-## Table of Contents
+## Table of Contents <!-- omit in toc -->
 
 - [Command Line Tools](#command-line-tools)
+  - [Command Line Tools (CLI)](#command-line-tools-cli)
 - [Homebrew](#homebrew)
+  - [Homebrew dupes](#homebrew-dupes)
+  - [Homebrew versions](#homebrew-versions)
+  - [Homebrew Cask (http://caskroom.io/)](#homebrew-cask-httpcaskroomio)
 - [Dropbox](#dropbox)
 - [Google Drive](#google-drive)
 - [Google Chrome](#google-chrome)
@@ -29,33 +33,46 @@ After having maintained [this gist](https://gist.github.com/danguita/6242852/rev
 - [ngrok](#ngrok)
 - [Exuberant Ctags](#exuberant-ctags)
 - [Ranger](#ranger)
-- [Gist](#gist-client)
+- [Gist client](#gist-client)
 - [Tmux](#tmux)
 - [Rainbarf](#rainbarf)
 - [Docker](#docker)
+  - [Docker hub](#docker-hub)
 - [Postgresql](#postgresql)
+  - [Postgresql: Avoid passing a host](#postgresql-avoid-passing-a-host)
+  - [Postgresql: Install `pg` gem on x86_64](#postgresql-install-pg-gem-on-x86_64)
 - [MySQL](#mysql)
 - [Elasticsearch](#elasticsearch)
+  - [Elasticsearch-head plugin](#elasticsearch-head-plugin)
 - [Redis](#redis)
-- [Capybara](#capybara-dependencies)
+- [Capybara dependencies](#capybara-dependencies)
 - [Imagemagick](#imagemagick)
+  - [libMagick: Dynamic libraries](#libmagick-dynamic-libraries)
 - [Ghostscript](#ghostscript)
 - [Weechat](#weechat)
-- [Twitter](#twitter-client)
+  - [Weechat Scripts](#weechat-scripts)
+  - [TOR](#tor)
+  - [Set up IRC SASL:](#set-up-irc-sasl)
+- [Twitter client](#twitter-client)
+  - [Rainbowstream: Run with `image-on-term`](#rainbowstream-run-with-image-on-term)
 - [Livestreamer](#livestreamer)
 - [Ruby](#ruby)
+  - [Install rubies](#install-rubies)
 - [Nodejs](#nodejs)
-- [Bower](#bower)
+  - [npm](#npm)
+  - [nvm](#nvm)
+- [bower](#bower)
 - [VirtualBox](#virtualbox)
 - [Vagrant](#vagrant)
+  - [Keep VirtualBox Guest Additions updated](#keep-virtualbox-guest-additions-updated)
 - [Packer](#packer)
 - [X11](#x11)
-- [Java runtime](#java-runtime)
+- [Java Runtime](#java-runtime)
 - [Microsoft IE OVA images](#microsoft-ie-ova-images)
 
 - - -
 
-## The Checklist
+## The Checklist <!-- omit in toc -->
 
 ### Command Line Tools
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ xcode-select --install
 Follow instructions from http://brew.sh
 
 ```
-ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
 
 #### Homebrew dupes

--- a/README.md
+++ b/README.md
@@ -109,25 +109,25 @@ brew tap homebrew/versions
 ### Dropbox
 
 ```
-brew cask install dropbpox
+brew install --cask dropbpox
 ```
 
 ### Google Drive
 
 ```
-brew cask install google-drive
+brew install --cask google-drive
 ```
 
 ### Google Chrome
 
 ```
-brew cask install google-chrome
+brew install --cask google-chrome
 ```
 
 ### iTerm2
 
 ```
-brew cask install iterm2
+brew install --cask iterm2
 ```
 
 ### Git
@@ -176,7 +176,7 @@ ln -s /usr/local/opt/freetype/include/freetype2 /usr/local/include/freetype
 ### Fonts
 
 ```
-brew cask install caskroom/fonts/font-hack # Hack
+brew install --cask caskroom/fonts/font-hack # Hack
 ```
 
 ### Curl
@@ -227,7 +227,7 @@ sudo mv /etc/zshenv /etc/zprofile # system-wide environment settings
 
 ```
 brew install vim
-brew cask install macvim
+brew install --cask macvim
 mkdir ~/Applications
 brew linkapps
 ```
@@ -451,13 +451,13 @@ npm install bower
 ### VirtualBox
 
 ```
-brew cask install virtualbox
+brew install --cask virtualbox
 ```
 
 ### Vagrant
 
 ```
-brew cask install vagrant
+brew install --cask vagrant
 ```
 
 #### Keep VirtualBox Guest Additions updated
@@ -476,7 +476,7 @@ brew install packer
 ### X11
 
 ```
-brew cask install xquartz
+brew install --cask xquartz
 ```
 
 ### Java Runtime

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ After having maintained [this gist](https://gist.github.com/danguita/6242852/rev
 - [Homebrew](#homebrew)
   - [Homebrew dupes](#homebrew-dupes)
   - [Homebrew versions](#homebrew-versions)
-  - [Homebrew Cask (http://caskroom.io/)](#homebrew-cask-httpcaskroomio)
 - [Dropbox](#dropbox)
 - [Google Drive](#google-drive)
 - [Google Chrome](#google-chrome)
@@ -105,12 +104,6 @@ brew tap homebrew/dupes
 
 ```
 brew tap homebrew/versions
-```
-
-#### Homebrew Cask (http://caskroom.io/)
-
-```
-brew install caskroom/cask/brew-cask
 ```
 
 ### Dropbox


### PR DESCRIPTION
Some commands are deprecated 😄 

- Updated Homebrew install command (with the command of the [official doc](https://brew.sh/))
- Updated the commands that used `brew cask ...`
- Restructuring the table of contents 